### PR TITLE
Simplify License Process

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: private-ai
 description: A Helm chart that deploys the Private AI deidentification solution
 
-version: 1.2.1
+version: 1.2.2
 
 # This is the default version deployed by the chart.
 # However, this is simply a label - if you wish to change the version, update your values.yaml

--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@ sh helper_scripts/create-kubesecret.sh
 # Login to the helm registry with your docker credentials
 helm registry login crprivateaiprod.azurecr.io
 
-# Optional - View and change the default helm values to customize your deployment. Add -f values.yaml.custom to the next command
-helm show values oci://crprivateaiprod.azurecr.io/helm/private-ai:1.2.1 > values.yaml.custom
+# Create a custom values file for your specific installation
+helm show values oci://crprivateaiprod.azurecr.io/helm/private-ai:1.2.2 > values.yaml.custom
 
-# Create a license values file from your license.json to enable the pod to startup successfully
-echo -e "license:\n  data: '$(cat license.json)'" > license.yaml
+# Copy your license.json file and paste it into license.data with single quotes surrounding, as per below
+license:
+  data: '{"id":"..."}'
 
 # Upgrade or install the Private AI chart with a name and namespace of private-ai
 helm upgrade --install \
 --namespace private-ai \
 private-ai \
--f license.yaml \
+-f values.yaml.custom \
 oci://crprivateaiprod.azurecr.io/helm/private-ai \
---version 1.2.1
+--version 1.2.2
 ```
 
 ## Testing

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Successfully installed {{ .Release.Name }} version {{ .Chart.AppVersion }}
 {{- if .Values.ingress.enabled }}
 To test the ingress connectivity, run the following
-      curl {{ if .Values.ingress.selfsigned }}-k {{ end }}http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}/
+      curl {{ if .Values.ingress.selfsigned }}-k {{ end }}https://{{ .Values.ingress.host }}/
 {{- else if eq "LoadBalancer" .Values.service.type }}
 
 NOTE: It can take a few minutes to download and start the container.

--- a/values.yaml
+++ b/values.yaml
@@ -33,7 +33,7 @@ license:
   name: "pai-license"
   volumeMount: "license-volume"
   mountPath: "/app/license"
-  data: "Override with your license data. See readme for more details"
+  data: 'Override with your license data. See readme for more details'
 
 envVars: []
   # Enter any environment variables for your deployment. You can find the list at https://docs.private-ai.com/environment-variables/
@@ -75,6 +75,8 @@ ingressnginx:
 # Requires ingress-nginx and cert-manager to be installed
 ingress:
   enabled: false
+  # Provision selfsigned certificates by default. Change if you wish to customize
+  selfsigned: true
   # Replace this with the domain name for the ingress
   host: "ingress.domain.com"
   tlsSecretName: "private-ai-tls"


### PR DESCRIPTION
## Purpose
<!-- Why are we doing this? -->
The license steps are a little brittle (it's hard to pass a JSON file as a string to be added to a configmap through helm) so I've updated the steps to be a bit simpler.

## What's changed
<!-- list of changes-->
- Simplify the license process, just always use a custom values file
- Fix notes for ingress with self-signed TLS
- Bump version to 1.2.2

## Testing
- [X] Tested locally with helm lint
- [X] Tested by Github CI

## Checklist
- [X] Update chart version if planning a release
- [X] Update README.md
