### PR TITLE
Update deployment probes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -50,8 +50,22 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.service.targetPort }}
-            periodSeconds: {{ .Values.service.periodSeconds }}
-            initialDelaySeconds: {{ .Values.service.initialDelaySeconds }}
+            periodSeconds: {{ .Values.service.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.service.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.service.timeoutSeconds }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.targetPort }}
+            periodSeconds: {{ .Values.service.startupProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.service.startupProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.service.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.targetPort }}
+            periodSeconds: {{ .Values.service.readinessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.service.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.service.timeoutSeconds }}
       volumes:
         - name: {{ .Values.license.volumeMount }}

--- a/values.yaml
+++ b/values.yaml
@@ -25,9 +25,16 @@ service:
   type: "LoadBalancer"
   port: 80
   targetPort: 8080
-  periodSeconds: 60
-  initialDelaySeconds: 120
   timeoutSeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 1800
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 60
 
 license:
   name: "pai-license"


### PR DESCRIPTION
## Purpose
The current implementation we have only does liveness checks. The purpose of this PR is to implement readiness and startup probes as well.

## What's changed
- Readiness and startup probes are added
- `values.yaml` updated with new variables. I set some default values in this file that I think make sense.

## Testing
- [x] Tested locally with helm lint
- [x] Tested by Github CI

## Checklist
- [ ] Update chart version if planning a release
- [ ] Update README.md
