### PR TITLE
Updates to health check probes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 ## Testing
 - [ ] Tested locally with helm lint
 - [ ] Tested by Github CI
+- [ ] Tested in a local cluster
 
 ## Checklist
 - [ ] Update chart version if planning a release

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: private-ai
 description: A Helm chart that deploys the Private AI deidentification solution
 
-version: 1.3.0
+version: 1.4.0
 
 # This is the default version deployed by the chart.
 # However, this is simply a label - if you wish to change the version, update your values.yaml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ kubectl -n private-ai create secret docker-registry crprivateaiprod-creds \
 helm registry login crprivateaiprod.azurecr.io
 
 # Create a custom values file for your specific installation
-helm show values oci://crprivateaiprod.azurecr.io/helm/private-ai:1.3.0 > values.custom.yaml
+helm show values oci://crprivateaiprod.azurecr.io/helm/private-ai:1.4.0 > values.custom.yaml
 
 # Copy your license.json file contents and paste them into the license.data section of the values.custom.yaml file with single quotes surrounding, as per below
 license:
@@ -40,7 +40,7 @@ helm upgrade --install \
 private-ai \
 -f values.custom.yaml \
 oci://crprivateaiprod.azurecr.io/helm/private-ai \
---version 1.3.0
+--version 1.4.0
 ```
 
 ## Testing
@@ -139,5 +139,5 @@ helm upgrade --install \
 private-ai \
 -f values.custom.yaml \
 oci://crprivateaiprod.azurecr.io/helm/private-ai \
---version 1.3.0
+--version 1.4.0
 ```

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -48,35 +48,35 @@ spec:
             - name: dshm-volume
               mountPath: /dev/shm
           {{- end }}
-          {{- if .Values.service.livenessProbe.enabled }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.service.targetPort }}
-            periodSeconds: {{ .Values.service.livenessProbe.periodSeconds }}
-            initialDelaySeconds: {{ .Values.service.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.service.timeoutSeconds }}
-            failureThreshold: {{ .Values.service.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.service.startupProbe.enabled }}
+          {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.service.targetPort }}
-            periodSeconds: {{ .Values.service.startupProbe.periodSeconds }}
-            initialDelaySeconds: {{ .Values.service.startupProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.service.timeoutSeconds }}
-            failureThreshold: {{ .Values.service.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.service.readinessProbe.enabled }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.service.targetPort }}
-            periodSeconds: {{ .Values.service.readinessProbe.periodSeconds }}
-            initialDelaySeconds: {{ .Values.service.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.service.timeoutSeconds }}
-            failureThreshold: {{ .Values.service.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
       volumes:
         - name: {{ .Values.license.volumeMount }}

--- a/values.yaml
+++ b/values.yaml
@@ -28,24 +28,27 @@ service:
   type: "LoadBalancer"
   port: 80
   targetPort: 8080
-  timeoutSeconds: 10
-  # These are the values for liveness, startup and readiness probes.
-  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#probe-v1-core
-  livenessProbe:
-    enabled: False
-    initialDelaySeconds: 120
-    periodSeconds: 1800
-    failureThreshold: 3
-  startupProbe:
-    enabled: True
-    initialDelaySeconds: 60
-    periodSeconds: 10
-    failureThreshold: 3
-  readinessProbe:
-    enabled: True
-    initialDelaySeconds: 60
-    periodSeconds: 60
-    failureThreshold: 3
+  timeoutSeconds: 1
+
+# These are the values for liveness, startup and readiness probes.
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#probe-v1-core
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 60
+  periodSeconds: 60
+  failureThreshold: 30
+startupProbe:
+  # Note: You should expect to see warnings for startup probe failures in the pod events until the container starts
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 23
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 20
+  failureThreshold: 3
+
 
 # Settings for the Private AI license file
 license:


### PR DESCRIPTION
## Purpose
<!-- Why are we doing this? -->
Would like to reorganize the values file a little bit in anticipation of async file support. Also modified the values slightly

## What's changed
<!-- list of changes-->
- Moved the probes out of the service block
- Updated default values
- Bump from 1.3.0 to 1.4.0

## Testing
- [X] Tested locally with helm lint
- [X] Tested by Github CI
- [X] Tested in a local cluster

## Checklist
- [X] Update chart version if planning a release
- [X] Update README.md
